### PR TITLE
Update StringUtils.cs - SanitizeHtml method

### DIFF
--- a/Westwind.AspNetCore.Markdown/Utilities/StringUtils.cs
+++ b/Westwind.AspNetCore.Markdown/Utilities/StringUtils.cs
@@ -167,7 +167,7 @@ namespace Westwind.AspNetCore.Markdown.Utilities
             if (string.IsNullOrEmpty(html))
                 return html;
 
-            if (!string.IsNullOrEmpty(htmlTagBlacklist) || htmlTagBlacklist == HtmlSanitizeTagBlackList)
+            if (string.IsNullOrEmpty(htmlTagBlacklist) || htmlTagBlacklist == HtmlSanitizeTagBlackList)
             {
                 // Replace Script tags - reused expr is more efficient
                 html = _RegExScript.Replace(html, string.Empty);


### PR DESCRIPTION
In SanitizeHtml method, htmlTagBlacklist was not used, therefore customization of taglist was not taken into account.