### PR TITLE
Remove requirement for MVC Controller with an optional mechanism for using a static Html template that can be processed directly by the middleware.

### DIFF
--- a/SampleWeb/Components/ErrorPage.razor
+++ b/SampleWeb/Components/ErrorPage.razor
@@ -1,0 +1,5 @@
+<h3>ErrorPage</h3>
+
+@code {
+
+}

--- a/SampleWeb/Controllers/MarkdownController.cs
+++ b/SampleWeb/Controllers/MarkdownController.cs
@@ -1,60 +1,60 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+﻿//using System;
+//using System.Collections.Generic;
+//using System.IO;
+//using System.Linq;
 //using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
-using Westwind.AspNetCore.Markdown;
+////using System.Threading.Tasks;
+//using Microsoft.AspNetCore.Hosting;
+//using Microsoft.AspNetCore.Mvc;
+//using Westwind.AspNetCore.Markdown;
 
-namespace SampleWeb.Controllers
-{
-    public class MarkdownController : Controller
-    {
-        private readonly IWebHostEnvironment hostingEnvironment;
+//namespace SampleWeb.Controllers
+//{
+//    public class MarkdownController : Controller
+//    {
+//        private readonly IWebHostEnvironment hostingEnvironment;
 
-        public MarkdownController(IWebHostEnvironment hostingEnvironment)
-        {
-            this.hostingEnvironment = hostingEnvironment;
-        }
+//        public MarkdownController(IWebHostEnvironment hostingEnvironment)
+//        {
+//            this.hostingEnvironment = hostingEnvironment;
+//        }
 
-        [Route("markdown/markdownpage")]
-        public async Task<IActionResult> MarkdownPage()
-        {            
-            var basePath = hostingEnvironment.WebRootPath;
-            var relativePath = HttpContext.Items["MarkdownPath_OriginalPath"] as string;
-            if (relativePath == null)
-                return NotFound();
+//        [Route("xmarkdown/markdownpage")]
+//        public async Task<IActionResult> MarkdownPage()
+//        {            
+//            var basePath = hostingEnvironment.WebRootPath;
+//            var relativePath = HttpContext.Items["MarkdownPath_OriginalPath"] as string;
+//            if (relativePath == null)
+//                return NotFound();
 
-            relativePath = NormalizePath(relativePath).Substring(1);
-            var pageFile = Path.Combine(basePath,relativePath);            
-            if (!System.IO.File.Exists(pageFile))
-                return NotFound();
+//            relativePath = NormalizePath(relativePath).Substring(1);
+//            var pageFile = Path.Combine(basePath,relativePath);            
+//            if (!System.IO.File.Exists(pageFile))
+//                return NotFound();
 
-            var markdown = await System.IO.File.ReadAllTextAsync(pageFile);
-            if (string.IsNullOrEmpty(markdown))
-                return NotFound();
+//            var markdown = await System.IO.File.ReadAllTextAsync(pageFile);
+//            if (string.IsNullOrEmpty(markdown))
+//                return NotFound();
 
-            ViewBag.MarkdownText = Markdown.ParseHtmlString(markdown);
-            return View("MarkdownPage");
-        }
+//            ViewBag.MarkdownText = Markdown.ParseHtmlString(markdown);
+//            return View("MarkdownPage");
+//        }
 
-        /// <summary>
-        /// Normalizes a file path to the operating system default
-        /// slashes.
-        /// </summary>
-        /// <param name="path"></param>
-        static string NormalizePath(string path)
-        {
-            //return Path.GetFullPath(path); // this always turns into a full OS path
+//        /// <summary>
+//        /// Normalizes a file path to the operating system default
+//        /// slashes.
+//        /// </summary>
+//        /// <param name="path"></param>
+//        static string NormalizePath(string path)
+//        {
+//            //return Path.GetFullPath(path); // this always turns into a full OS path
 
-            if (string.IsNullOrEmpty(path))
-                return path;
+//            if (string.IsNullOrEmpty(path))
+//                return path;
 
-            char slash = Path.DirectorySeparatorChar;
-            path = path.Replace('/', slash).Replace('\\', slash);
-            return path.Replace(slash.ToString() + slash.ToString(), slash.ToString());
-        }
-    }
-}
+//            char slash = Path.DirectorySeparatorChar;
+//            path = path.Replace('/', slash).Replace('\\', slash);
+//            return path.Replace(slash.ToString() + slash.ToString(), slash.ToString());
+//        }
+//    }
+//}

--- a/SampleWeb/Program.cs
+++ b/SampleWeb/Program.cs
@@ -21,8 +21,8 @@ builder.Services.AddMarkdown(config =>
     config.MarkdownRenderExtensions.Add(new PlantUmlMarkdownRenderExtension());
     config.MarkdownRenderExtensions.Add(new FontAwesomeRenderExtension());
 
-    //config.MarkdownPageMode = MarkdownPageModes.ControllerAndView;
-    config.MarkdownPageMode = MarkdownPageModes.MiddlewareAndStaticHtmlFile;
+    config.MarkdownPageMode = MarkdownPageModes.ControllerAndView;
+    //config.MarkdownPageMode = MarkdownPageModes.MiddlewareAndStaticHtmlFile;
 
     var folderConfig = config.AddMarkdownProcessingFolder("/docs/", "~/Pages/__MarkdownPageTemplate.cshtml");
     folderConfig = config.AddMarkdownProcessingFolder("/posts/", "~/Pages/__MarkdownPageTemplate.cshtml");

--- a/SampleWeb/Program.cs
+++ b/SampleWeb/Program.cs
@@ -1,10 +1,23 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using SampleWeb.Components;
 using Westwind.AspNetCore.Markdown;
+using Markdown = Westwind.AspNetCore.Markdown.Markdown;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +28,9 @@ builder.Services.AddMarkdown(config =>
 
     config.MarkdownRenderExtensions.Add(new PlantUmlMarkdownRenderExtension());
     config.MarkdownRenderExtensions.Add(new FontAwesomeRenderExtension());
+
+    //config.MarkdownPageMode = MarkdownPageModes.ControllerAndView;
+    config.MarkdownPageMode = MarkdownPageModes.MiddlewareAndStaticHtmlFile;
 
     var folderConfig = config.AddMarkdownProcessingFolder("/docs/", "~/Pages/__MarkdownPageTemplate.cshtml");
     folderConfig = config.AddMarkdownProcessingFolder("/posts/", "~/Pages/__MarkdownPageTemplate.cshtml");
@@ -47,9 +63,11 @@ builder.Services.AddMarkdown(config =>
     };
 });
 
-builder.Services.AddMvc()
-    .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly)
-    .AddRazorRuntimeCompilation();
+builder.Services.AddRazorPages();
+
+//builder.Services.AddMvc()
+//    .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly)
+//    .AddRazorRuntimeCompilation();
 
 var app = builder.Build();
 
@@ -68,7 +86,97 @@ app.UseDefaultFiles(new DefaultFilesOptions()
     DefaultFileNames = new List<string> { "index.md", "index.html" }
 });
 
-app.UseMarkdown();
+
+    app.UseMarkdown();
+
+
+//app.Use(async (context, next) =>
+//    {
+//        var path = context.Request.Path.Value?.ToLower();
+
+//        if (!(path?.StartsWith("/markdownprocessor/markdownpage") ?? false))
+//        {
+//            await next(context);
+//            return;
+//        }
+
+//        var services = context.RequestServices;
+//        var markdownConfig = services.GetRequiredService<MarkdownConfiguration>() as MarkdownConfiguration;
+//        var hostingEnvironment = services.GetRequiredService<IWebHostEnvironment>() as IWebHostEnvironment;
+        
+
+//        if (markdownConfig.MarkdownPageMode != MarkdownPageModes.MiddlewareAndStaticHtmlFile)
+//        {
+//            var endpoints = services.GetRequiredService<EndpointDataSource>() as EndpointDataSource;
+//            // check if controller method is mapped - only if controllers are enabled
+//            if (endpoints.Endpoints
+//                .OfType<RouteEndpoint>()
+//                .Any(e => string.Equals(
+//                    e.RoutePattern.RawText,
+//                    "markdownprocessor/markdownpage",
+//                    StringComparison.OrdinalIgnoreCase)))            
+//            {
+//                await next(context);
+//                return;
+//            }
+//        }
+        
+//        var model = context.Items["MarkdownProcessor_Model"] as MarkdownModel;
+//        if (model == null)
+//            throw new InvalidOperationException(
+//                "This controller is not accessible directly unless the Markdown Model is set");
+
+//        var basePath = hostingEnvironment.WebRootPath;
+//        var relativePath = model.RelativePath;
+//        if (relativePath == null)
+//        {
+//            throw new FileNotFoundException();            
+//        }
+
+//        if (!File.Exists(model.PhysicalPath))
+//        {
+//            throw new FileNotFoundException("");            
+//        }
+
+//        // string markdown = await File.ReadAllTextAsync(pageFile);
+//        string markdown;
+//        using (var fs = new FileStream(model.PhysicalPath,
+//                   FileMode.Open,
+//                   FileAccess.Read))
+//        using (var sr = new StreamReader(fs))
+//        {
+//            markdown = await sr.ReadToEndAsync();
+//        }
+
+
+//        // set title, raw markdown, yamlheader and rendered markdown
+//        MarkdownPageProcessorController.ParseMarkdownToModel(markdown, model);
+
+//        string html = null;
+
+//        var staticTemplatePath = Path.Combine(hostingEnvironment.ContentRootPath, model.FolderConfiguration.StaticHtmlViewTemplate.Replace("~/", ""));
+//        if (!File.Exists(staticTemplatePath))
+//        {
+
+//            string staticTemplate = null;
+//            using (var fs = new FileStream(staticTemplatePath,
+//                       FileMode.Open,
+//                       FileAccess.Read))
+//            using (var sr = new StreamReader(fs))
+//            {
+//                staticTemplate = await sr.ReadToEndAsync();
+//            }
+//            html = staticTemplate.Replace("{{ RenderedMarkdown }}", model.RenderedMarkdown.ToString());
+//        }
+//        else
+//        {
+//            html = model.RenderedMarkdown?.ToString();
+//        }
+
+//        await context.Response.WriteAsync(html);
+//    });
+
+
 
 app.UseRouting();
 
@@ -81,3 +189,7 @@ app.UseEndpoints(endpoints =>
 });
 
 app.Run();
+
+
+
+

--- a/SampleWeb/Program.cs
+++ b/SampleWeb/Program.cs
@@ -1,29 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Hosting.Internal;
-using SampleWeb.Components;
 using Westwind.AspNetCore.Markdown;
-using Markdown = Westwind.AspNetCore.Markdown.Markdown;
 
 var builder = WebApplication.CreateBuilder(args);
+
+
+MarkdownConfiguration markdownConfiguration = null;
 
 // Add services to the container.
 builder.Services.AddMarkdown(config =>
 {
+    markdownConfiguration = config;
+
     config.HtmlTagBlackList = "script|iframe|object|embed|form";
 
     config.MarkdownRenderExtensions.Add(new PlantUmlMarkdownRenderExtension());
@@ -63,11 +55,19 @@ builder.Services.AddMarkdown(config =>
     };
 });
 
-builder.Services.AddRazorPages();
 
-//builder.Services.AddMvc()
-//    .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly)
-//    .AddRazorRuntimeCompilation();
+if (markdownConfiguration.MarkdownPageMode == MarkdownPageModes.MiddlewareAndStaticHtmlFile)
+{
+    // need Razor Pages for samples
+    builder.Services.AddRazorPages();
+}
+else
+{
+    // Only required for Markdown Template using Razor Views
+    builder.Services.AddMvc()
+       .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly)
+       .AddRazorRuntimeCompilation();
+}
 
 var app = builder.Build();
 
@@ -87,95 +87,7 @@ app.UseDefaultFiles(new DefaultFilesOptions()
 });
 
 
-    app.UseMarkdown();
-
-
-//app.Use(async (context, next) =>
-//    {
-//        var path = context.Request.Path.Value?.ToLower();
-
-//        if (!(path?.StartsWith("/markdownprocessor/markdownpage") ?? false))
-//        {
-//            await next(context);
-//            return;
-//        }
-
-//        var services = context.RequestServices;
-//        var markdownConfig = services.GetRequiredService<MarkdownConfiguration>() as MarkdownConfiguration;
-//        var hostingEnvironment = services.GetRequiredService<IWebHostEnvironment>() as IWebHostEnvironment;
-        
-
-//        if (markdownConfig.MarkdownPageMode != MarkdownPageModes.MiddlewareAndStaticHtmlFile)
-//        {
-//            var endpoints = services.GetRequiredService<EndpointDataSource>() as EndpointDataSource;
-//            // check if controller method is mapped - only if controllers are enabled
-//            if (endpoints.Endpoints
-//                .OfType<RouteEndpoint>()
-//                .Any(e => string.Equals(
-//                    e.RoutePattern.RawText,
-//                    "markdownprocessor/markdownpage",
-//                    StringComparison.OrdinalIgnoreCase)))            
-//            {
-//                await next(context);
-//                return;
-//            }
-//        }
-        
-//        var model = context.Items["MarkdownProcessor_Model"] as MarkdownModel;
-//        if (model == null)
-//            throw new InvalidOperationException(
-//                "This controller is not accessible directly unless the Markdown Model is set");
-
-//        var basePath = hostingEnvironment.WebRootPath;
-//        var relativePath = model.RelativePath;
-//        if (relativePath == null)
-//        {
-//            throw new FileNotFoundException();            
-//        }
-
-//        if (!File.Exists(model.PhysicalPath))
-//        {
-//            throw new FileNotFoundException("");            
-//        }
-
-//        // string markdown = await File.ReadAllTextAsync(pageFile);
-//        string markdown;
-//        using (var fs = new FileStream(model.PhysicalPath,
-//                   FileMode.Open,
-//                   FileAccess.Read))
-//        using (var sr = new StreamReader(fs))
-//        {
-//            markdown = await sr.ReadToEndAsync();
-//        }
-
-
-//        // set title, raw markdown, yamlheader and rendered markdown
-//        MarkdownPageProcessorController.ParseMarkdownToModel(markdown, model);
-
-//        string html = null;
-
-//        var staticTemplatePath = Path.Combine(hostingEnvironment.ContentRootPath, model.FolderConfiguration.StaticHtmlViewTemplate.Replace("~/", ""));
-//        if (!File.Exists(staticTemplatePath))
-//        {
-
-//            string staticTemplate = null;
-//            using (var fs = new FileStream(staticTemplatePath,
-//                       FileMode.Open,
-//                       FileAccess.Read))
-//            using (var sr = new StreamReader(fs))
-//            {
-//                staticTemplate = await sr.ReadToEndAsync();
-//            }
-//            html = staticTemplate.Replace("{{ RenderedMarkdown }}", model.RenderedMarkdown.ToString());
-//        }
-//        else
-//        {
-//            html = model.RenderedMarkdown?.ToString();
-//        }
-
-//        await context.Response.WriteAsync(html);
-//    });
-
+app.UseMarkdown();
 
 
 app.UseRouting();
@@ -185,7 +97,11 @@ app.UseStaticFiles();
 app.UseEndpoints(endpoints =>
 {
     endpoints.MapRazorPages();
-    endpoints.MapDefaultControllerRoute();
+    if (markdownConfiguration.MarkdownPageMode == MarkdownPageModes.ControllerAndView)
+    {
+        // controllers not required in MiddlewareAndStaticHtmlFile mode
+        endpoints.MapDefaultControllerRoute();
+    }
 });
 
 app.Run();

--- a/SampleWeb/SampleWeb.csproj
+++ b/SampleWeb/SampleWeb.csproj
@@ -3,6 +3,11 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="__MarkdownPageTemplate.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup>

--- a/SampleWeb/Views/Markdown/MarkdownPage.cshtml
+++ b/SampleWeb/Views/Markdown/MarkdownPage.cshtml
@@ -1,4 +1,4 @@
-﻿@model Westwind.AspNetCore.Markdown.MarkdownModel
+@model Westwind.AspNetCore.Markdown.MarkdownModel
 @{
     Layout = "_Layout";
     ViewBag.Title = Model.Title;
@@ -26,7 +26,7 @@
             }
     </style>
 }
-<div style="margin-top: 40px;">
+<div style="margin-top: 40px;">		
     @Model.RenderedMarkdown
 </div>
 

--- a/SampleWeb/Views/Shared/_Layout.cshtml
+++ b/SampleWeb/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -35,7 +35,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a asp-page="/Index" class="navbar-brand">Westwind.AspNetCore</a>
+                <a asp-page="/Index" class="navbar-brand">VIEW TEMPLATE - Westwind.AspNetCore</a>
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">

--- a/SampleWeb/Views/__MarkdownPageTemplate.cshtml
+++ b/SampleWeb/Views/__MarkdownPageTemplate.cshtml
@@ -1,4 +1,4 @@
-﻿@model Westwind.AspNetCore.Markdown.MarkdownModel
+@model Westwind.AspNetCore.Markdown.MarkdownModel
 @{
     Layout = "_Layout";
     ViewBag.Title = Model.Title;

--- a/SampleWeb/__MarkdownPageTemplate.html
+++ b/SampleWeb/__MarkdownPageTemplate.html
@@ -1,0 +1,116 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Creating a generic Markdown Page Handler in ASP.NET Core - Westwind.AspNetCore</title>
+
+    
+        <link rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap.css" />
+        <link rel="stylesheet" href="/css/site.css" />
+    
+    
+
+    <link href="/lib/FontAwesome/css/all.min.css" rel="stylesheet">
+    <style>
+        img {
+            max-width: 100%
+        }
+    </style>
+    
+    <style>
+        h3 {
+            margin-top: 50px;
+            padding-bottom: 10px;
+            border-bottom: 1px solid #eee;
+        }
+        /* vs2015 theme specific*/
+        pre {
+            background: #1E1E1E;
+            color: #eee;
+            padding: 0.5em !important;
+            overflow-x: auto;
+            white-space: pre;
+            word-break: normal;
+            word-wrap: normal;
+        }
+
+        pre > code {
+            white-space: pre;
+        }
+    </style>
+
+</head>
+<body>
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+        <div class="container">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="/">Westwind.AspNetCore</a>
+            </div>
+            <div class="navbar-collapse collapse">
+                <ul class="nav navbar-nav">
+                    <li><a href="/">Home</a></li>
+                    <li><a href="https://github.com/RickStrahl/Westwind.AspNetCore.Markdown">GitHub</a></li>
+                    <li><a href="https://weblog.west-wind.com">Contact</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container body-content">
+        <div style="margin-top: 40px;">
+            <h1>STATIC RENDERED PAGE</h1>
+
+            {{ RenderedMarkdown }}
+        </div>
+    </div>
+
+
+       
+        <hr />
+        <footer>
+            <div class="pull-right">
+                <a href="https://west-wind.com">
+                    <img src="/images/WestWindText.png" />
+                </a>
+            </div>
+            <p>&copy; 2026, West Wind Technologies</p>
+        </footer>
+    </div>
+
+    
+        <script src="/lib/jquery/dist/jquery.js"></script>
+        <script src="/lib/bootstrap/dist/js/bootstrap.js"></script>
+        <script src="/js/site.js?v=EWaMeWsJBYWmL2g_KkgXZQ5nPe-a3Ichp0LEgzXczKo"></script>
+    
+    
+
+    
+    <!-- Syntax Highlighting code -->
+    <script src="/lib/highlightjs/highlight.pack.js"></script>
+    <link href="/lib/highlightjs/styles/vs2015.css" rel="stylesheet" />
+    <script src="/lib/highlightjs-badge.js"></script>
+
+    <script>
+        // apply HighlightJS
+        var pres = document.querySelectorAll("pre>code");
+        for (var i = 0; i < pres.length; i++) {
+            hljs.highlightBlock(pres[i]);
+        }
+
+        // https://github.com/RickStrahl/highlightjs-badge
+        window.highlightJsBadge();
+    </script>
+
+
+<!-- Visual Studio Browser Link -->
+<script type="text/javascript" src="/_vs/browserLink" async="async" id="__browserLink_initializationData" data-requestId="7204c656237e44388e02d7db2cd4aeed" data-requestMappingFromServer="false" data-connectUrl="http://localhost:54233/3a954f75d5074279a2471b20b1501afb/browserLink"></script>
+<!-- End Browser Link -->
+<script src="/_framework/aspnetcore-browser-refresh.js"></script></body>
+</html>

--- a/SampleWeb/__MarkdownPageTemplate.html
+++ b/SampleWeb/__MarkdownPageTemplate.html
@@ -107,8 +107,5 @@
     </script>
 
 
-<!-- Visual Studio Browser Link -->
-<script type="text/javascript" src="/_vs/browserLink" async="async" id="__browserLink_initializationData" data-requestId="7204c656237e44388e02d7db2cd4aeed" data-requestMappingFromServer="false" data-connectUrl="http://localhost:54233/3a954f75d5074279a2471b20b1501afb/browserLink"></script>
-<!-- End Browser Link -->
-<script src="/_framework/aspnetcore-browser-refresh.js"></script></body>
+</body>
 </html>

--- a/SampleWeb/__MarkdownPageTemplate.html
+++ b/SampleWeb/__MarkdownPageTemplate.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Creating a generic Markdown Page Handler in ASP.NET Core - Westwind.AspNetCore</title>
+    <title>{{ Title }}</title>
 
     
         <link rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap.css" />
@@ -52,7 +52,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="/">Westwind.AspNetCore</a>
+                <a class="navbar-brand" href="/">STATIC TEMPLATE - Westwind.AspNetCore</a>
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
@@ -64,9 +64,7 @@
         </div>
     </nav>
     <div class="container body-content">
-        <div style="margin-top: 40px;">
-            <h1>STATIC RENDERED PAGE</h1>
-
+        <div style="margin-top: 40px;">            
             {{ RenderedMarkdown }}
         </div>
     </div>

--- a/Westwind.AspNetCore.Markdown/MarkdownConfiguration.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownConfiguration.cs
@@ -11,6 +11,7 @@ namespace Westwind.AspNetCore.Markdown;
 public class MarkdownConfiguration
 {
     public const string DefaultMarkdownViewTemplate = "~/Views/__MarkdownPageTemplate.cshtml";
+    public const string DefaultStaticHtmlTemplate = "~/__MarkdownPageTemplate.html";
 
     /// <summary>
     /// List of relative virtual folders where any extensionless URL is
@@ -37,6 +38,11 @@ public class MarkdownConfiguration
     /// Global HtmlTagBlackList when StripScriptTags is set for Markdown parsing
     /// </summary>
     public string HtmlTagBlackList { get; set; } = "script|iframe|object|embed|form";
+
+    /// <summary>
+    /// Determines the mode in which the Markdown pages are processed.
+    /// </summary>
+    public MarkdownPageModes MarkdownPageMode { get; set; } = MarkdownPageModes.ControllerAndView;
 
     /// <summary>
     /// Adds a folder to the list of folders that are to be
@@ -101,9 +107,15 @@ public class MarkdownProcessingFolder
     public string BasePath {get; set;}
 
     /// <summary>
-    /// View Template to use to render the Markdown page
+    /// Controller View Template to use to render the Markdown page
     /// </summary>
     public string ViewTemplate { get; set; } = MarkdownConfiguration.DefaultMarkdownViewTemplate;
+
+    /// <summary>
+    /// View Template to use to render the Markdown page
+    /// </summary>
+    public string StaticHtmlViewTemplate { get; set;  } = MarkdownConfiguration.DefaultStaticHtmlTemplate;
+
 
     /// <summary>
     /// If true processes files with .md extension
@@ -149,4 +161,10 @@ public class MarkdownProcessingFolder
     /// the final HTML output.
     /// </summary>
     public Action<MarkdownModel, Controller> PreProcess { get; set; }
+}
+
+public enum MarkdownPageModes
+{
+    ControllerAndView,
+    MiddlewareAndStaticHtmlFile
 }

--- a/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorController.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorController.cs
@@ -71,7 +71,7 @@ public class MarkdownPageProcessorController : Controller
         return View(MarkdownConfiguration.DefaultMarkdownViewTemplate, model);
     }
 
-    public static  MarkdownModel ParseMarkdownToModel(string markdown, MarkdownModel model = null)
+    internal static MarkdownModel ParseMarkdownToModel(string markdown, MarkdownModel model = null)
     {
         if (model == null)
             model = new MarkdownModel();

--- a/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorController.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorController.cs
@@ -71,7 +71,7 @@ public class MarkdownPageProcessorController : Controller
         return View(MarkdownConfiguration.DefaultMarkdownViewTemplate, model);
     }
 
-    private MarkdownModel ParseMarkdownToModel(string markdown, MarkdownModel model = null)
+    public static  MarkdownModel ParseMarkdownToModel(string markdown, MarkdownModel model = null)
     {
         if (model == null)
             model = new MarkdownModel();

--- a/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
@@ -150,7 +150,7 @@ public class MarkdownPageProcessorMiddleware
     /// <param name="model"></param>
     /// <returns></returns>
     /// <exception cref="FileNotFoundException"></exception>
-    public async Task<bool> NoControllerProcessing(HttpContext context, RequestDelegate next,  MarkdownModel model)
+    private async Task<bool> NoControllerProcessing(HttpContext context, MarkdownModel model)
     {
         var path = context.Request.Path.Value?.ToLower();
 

--- a/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
@@ -194,7 +194,10 @@ public class MarkdownPageProcessorMiddleware
             {
                 staticTemplate = await sr.ReadToEndAsync();
             }
-            html = staticTemplate.Replace("{{ RenderedMarkdown }}", model.RenderedMarkdown.ToString());
+            
+            html = staticTemplate
+                .Replace("{{ RenderedMarkdown }}", model.RenderedMarkdown.ToString() )
+                .Replace("{{ Title }}", model.Title);
         }
         else
         {

--- a/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
@@ -178,6 +178,12 @@ public class MarkdownPageProcessorMiddleware
         }
 
 
+        if (string.IsNullOrEmpty(markdown))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return true;
+        }
+
         // set title, raw markdown, yamlheader and rendered markdown
         MarkdownPageProcessorController.ParseMarkdownToModel(markdown, model);
 

--- a/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
@@ -70,6 +70,8 @@ public class MarkdownPageProcessorMiddleware
             return;
         }
 
+        context.Response.ContentType = "text/html; charset=utf-8";
+
         bool hasExtension = !string.IsNullOrEmpty(Path.GetExtension(path));
         bool hasMdExtension = path.EndsWith(".md", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".markdown", StringComparison.OrdinalIgnoreCase);
         bool isRoot = path == "/";
@@ -127,7 +129,7 @@ public class MarkdownPageProcessorMiddleware
 
                 if (_configuration.MarkdownPageMode == MarkdownPageModes.MiddlewareAndStaticHtmlFile)
                 {
-                    bool handled = await NoControllerProcessing(context, _next, model);
+                    await NoControllerProcessing(context, model);
                     return;  // we generated output so don't continue processing
                 }
 
@@ -168,16 +170,7 @@ public class MarkdownPageProcessorMiddleware
         }
 
         // string markdown = await File.ReadAllTextAsync(pageFile);
-        string markdown;
-        using (var fs = new FileStream(model.PhysicalPath,
-                   FileMode.Open,
-                   FileAccess.Read))
-        using (var sr = new StreamReader(fs))
-        {
-            markdown = await sr.ReadToEndAsync();
-        }
-
-
+        var markdown = await File.ReadAllTextAsync(model.PhysicalPath);
         if (string.IsNullOrEmpty(markdown))
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
@@ -191,17 +184,11 @@ public class MarkdownPageProcessorMiddleware
 
         var staticTemplatePath = Path.Combine(_env.ContentRootPath, model.FolderConfiguration.StaticHtmlViewTemplate.Replace("~/", ""));
         if (File.Exists(staticTemplatePath))
-        {
-            string staticTemplate = null;
-            using (var fs = new FileStream(staticTemplatePath,
-                       FileMode.Open,
-                       FileAccess.Read))
-            using (var sr = new StreamReader(fs))
-            {
-                staticTemplate = await sr.ReadToEndAsync();
-            }
+        {            
+            var staticTemplate = await File.ReadAllTextAsync(staticTemplatePath);            
             
             html = staticTemplate
+                .Replace("{{ RenderedContent }}", model.RenderedMarkdown.ToString())
                 .Replace("{{ RenderedMarkdown }}", model.RenderedMarkdown.ToString() )
                 .Replace("{{ Title }}", model.Title);
         }
@@ -210,7 +197,7 @@ public class MarkdownPageProcessorMiddleware
             html = model.RenderedMarkdown?.ToString();
         }
 
-        await context.Response.WriteAsync(html);
+        await context.Response.WriteAsync(html ?? string.Empty);
         return true;
     }
 }

--- a/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
+++ b/Westwind.AspNetCore.Markdown/MarkdownPageProcessorMiddleware/MarkdownPageProcessorMiddleware.cs
@@ -61,11 +61,14 @@ public class MarkdownPageProcessorMiddleware
         this._env = _env;
     }
 
-    public Task InvokeAsync(HttpContext context)
+    public async Task InvokeAsync(HttpContext context)
     {
         var path = context.Request.Path.Value;
         if (string.IsNullOrEmpty(path))
-            return _next(context);
+        { 
+            await _next(context);
+            return;
+        }
 
         bool hasExtension = !string.IsNullOrEmpty(Path.GetExtension(path));
         bool hasMdExtension = path.EndsWith(".md", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".markdown", StringComparison.OrdinalIgnoreCase);
@@ -122,12 +125,83 @@ public class MarkdownPageProcessorMiddleware
                 // push the model into the context for controller to pick up
                 context.Items["MarkdownProcessor_Model"] = model;
 
+                if (_configuration.MarkdownPageMode == MarkdownPageModes.MiddlewareAndStaticHtmlFile)
+                {
+                    bool handled = await NoControllerProcessing(context, _next, model);
+                    return;  // we generated output so don't continue processing
+                }
+
                 // rewrite path to our controller so we can use _layout page
                 context.Request.Path = "/markdownprocessor/markdownpage";
+
                 break;
             }
         }
 
-        return _next(context);
+        await _next(context);        
+    }
+
+
+    /// <summary>
+    /// Processes the markdown file directly in the middleware without going through the controller.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="next"></param>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    /// <exception cref="FileNotFoundException"></exception>
+    public async Task<bool> NoControllerProcessing(HttpContext context, RequestDelegate next,  MarkdownModel model)
+    {
+        var path = context.Request.Path.Value?.ToLower();
+
+              
+        var basePath = _env.WebRootPath;
+        var relativePath = model.RelativePath;
+        if (relativePath == null)
+        {
+            throw new FileNotFoundException();
+        }
+
+        if (!File.Exists(model.PhysicalPath))
+        {
+            throw new FileNotFoundException("");
+        }
+
+        // string markdown = await File.ReadAllTextAsync(pageFile);
+        string markdown;
+        using (var fs = new FileStream(model.PhysicalPath,
+                   FileMode.Open,
+                   FileAccess.Read))
+        using (var sr = new StreamReader(fs))
+        {
+            markdown = await sr.ReadToEndAsync();
+        }
+
+
+        // set title, raw markdown, yamlheader and rendered markdown
+        MarkdownPageProcessorController.ParseMarkdownToModel(markdown, model);
+
+        string html = null;
+
+        var staticTemplatePath = Path.Combine(_env.ContentRootPath, model.FolderConfiguration.StaticHtmlViewTemplate.Replace("~/", ""));
+        if (File.Exists(staticTemplatePath))
+        {
+            string staticTemplate = null;
+            using (var fs = new FileStream(staticTemplatePath,
+                       FileMode.Open,
+                       FileAccess.Read))
+            using (var sr = new StreamReader(fs))
+            {
+                staticTemplate = await sr.ReadToEndAsync();
+            }
+            html = staticTemplate.Replace("{{ RenderedMarkdown }}", model.RenderedMarkdown.ToString());
+        }
+        else
+        {
+            html = model.RenderedMarkdown?.ToString();
+        }
+
+        await context.Response.WriteAsync(html);
+        return true;
     }
 }

--- a/Westwind.AspNetCore.Markdown/Westwind.AspNetCore.Markdown.csproj
+++ b/Westwind.AspNetCore.Markdown/Westwind.AspNetCore.Markdown.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0;</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.41</Version>    
+    <Version>3.5</Version>    
     <Authors>Rick Strahl</Authors>
     <Company>West Wind Technologies</Company>
     <Product>West Wind Web Toolkit</Product>
@@ -21,7 +21,7 @@ This library provides Markdown support for ASP.NET Core applications:
  * TagHelper supports White Space Normalization
  * Customization of Markdown Processing Options
     </Description>
-    <Copyright>(c) West Wind Technologies, 2017-2025</Copyright>
+    <Copyright>(c) West Wind Technologies, 2017-2026</Copyright>
     <RepositoryUrl>https://github.com/RickStrahl/Westwind.AspNetCore.Markdown</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ This small package provides Markdown support for your ASP.NET Core applications.
 *  **[Markdown Page Processor Middleware](#markdown-page-processor-middleware)**
 	*  Serve `.md` files as Markdown
 	*  Serve mapped extensionless URLs as Markdown
-	*  Configure a Razor template to customize Markdown Page Container UI
+    *  Render with either an MVC Razor view template or a static HTML template
 *  **Configuration and Support Features**
 	* Uses the awesome [MarkDig Markdown Parser](https://github.com/lunet-io/markdig) by default
 	* Customizable Markdown Parsing Pipeline for Markdig
@@ -55,17 +55,36 @@ dotnet add package westwind.aspnetcore.markdown
 ```
 
 ## Startup Configuration
-To use these components you need to add the following to your Startup class at minimum. The following is for ASP.NET Core 3.0 and later using endpoint routing:
 
 ```cs
+MarkdownConfiguration markdownConfiguration = null;
+
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddMarkdown();
-	
-	// We need to use MVC so we can use a Razor Configuration Template
-    services.AddMvc()
-        // have to let MVC know we have a controller
-        .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly);
+    services.AddMarkdown(config =>
+    {
+        markdownConfiguration = config;
+
+        // Default: ControllerAndView
+        // config.MarkdownPageMode = MarkdownPageModes.ControllerAndView;
+
+        // Optional: no controller/view rewrite, render with static HTML template
+        // config.MarkdownPageMode = MarkdownPageModes.MiddlewareAndStaticHtmlFile;
+
+        var folder = config.AddMarkdownProcessingFolder("/docs/", "~/Views/__MarkdownPageTemplate.cshtml");
+
+        // Optional static template path for MiddlewareAndStaticHtmlFile mode.
+        // Default: ~/__MarkdownPageTemplate.html (relative to ContentRoot)
+        // folder.StaticHtmlViewTemplate = "~/__MarkdownPageTemplate.html";
+    });
+
+    // if using ControllerAndView here we use a controller to handle the template
+    // which allows for _Layout and logic in the template - MiddlewareAndStaticHtml requires just a file
+    if (markdownConfiguration.MarkdownPageMode == MarkdownPageModes.ControllerAndView)
+    {
+        services.AddMvc()
+            .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly);
+    }
 }
 
 public void Configure(IApplicationBuilder app)
@@ -78,16 +97,15 @@ public void Configure(IApplicationBuilder app)
     
     app.UseMarkdown();
     app.UseStaticFiles();
-    
-    // the following enables MVC and Razor Pages
+
     app.UseRouting();
-    
+
     app.UseEndpoints(endpoints =>
     {
-        // endpoints.MapRazorPages();  // optional
-        
-        // MVC routing is required
-        endpoints.MapDefaultControllerRoute();
+    
+        // Only required for ControllerAndView mode
+        if (markdownConfiguration.MarkdownPageMode == MarkdownPageModes.ControllerAndView)
+            endpoints.MapDefaultControllerRoute();
     });
 }
 ```
@@ -329,13 +347,18 @@ Optional parameter that can be set if you are using a URL bound to the tag helpe
 
 
 ## Markdown Page Processor Middleware
-The Markdown middleware allows you drop `.md` files into a configured folder and have that folder parsed directly from disk. The middleware merges the Markdown into a pre-configured Razor template you provide so your Markdown text can be rendered in the proper UI context of your site chrome. 
+The Markdown middleware allows you drop `.md` files into a configured folder and have that folder parsed directly from disk. Rendering can happen in two ways:
+
+* **Controller and View mode (default)**: rewrites to a controller endpoint that renders a Razor template.
+* **Middleware and Static HTML mode**: renders directly in middleware and merges into a static HTML template.
 
 To use this feature you need to do the following:
 
 * Use `AddMarkdown()` to **configure** the page processing
 * Use `UseMarkdown()` to **hook up** the middleware
-* Create a Markdown View Template (default is: `~/Views/__MarkdownPageTemplate.cshtml`)
+* Create a page template:
+    * Razor template default: `~/Views/__MarkdownPageTemplate.cshtml`
+    * Static HTML template default: `~/__MarkdownPageTemplate.html` (content root)
 * Create `.md` files for your content
 * Rock on!
 
@@ -351,13 +374,27 @@ At it's simplest you can just do:
 ```cs
 public void ConfigureServices(IServiceCollection services)
 {
+    MarkdownConfiguration markdownConfiguration = null;
+
     services.AddMarkdown(config =>
     {
+        markdownConfiguration = config;
+
         // just add a folder as is
-        config.AddMarkdownProcessingFolder("/docs/");
-        
-        services.AddMvc();
-    }
+        var folderConfig = config.AddMarkdownProcessingFolder("/docs/");
+
+        // Default mode: uses controller + Razor view template
+        config.MarkdownPageMode = MarkdownPageModes.ControllerAndView;
+
+        // Optional mode: direct middleware rendering with static HTML file
+        // config.MarkdownPageMode = MarkdownPageModes.MiddlewareAndStaticHtmlFile;
+        // folderConfig.StaticHtmlViewTemplate = "~/__MarkdownPageTemplate.html";
+    });
+
+    if (markdownConfiguration.MarkdownPageMode == MarkdownPageModes.MiddlewareAndStaticHtmlFile)
+        services.AddRazorPages();
+    else
+        services.AddMvc().AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly);
 }
 ```
 
@@ -374,6 +411,12 @@ services.AddMarkdown(config =>
 
     // Simplest: Use all default settings
     var folderConfig = config.AddMarkdownProcessingFolder("/docs/", "~/Pages/__MarkdownPageTemplate.cshtml");
+
+    // Choose rendering mode (default is ControllerAndView)
+    config.MarkdownPageMode = MarkdownPageModes.ControllerAndView;
+
+    // config.MarkdownPageMode = MarkdownPageModes.MiddlewareAndStaticHtmlFile;
+    // folderConfig.StaticHtmlViewTemplate = "~/__MarkdownPageTemplate.html";
     
     // Customized Configuration: Set FolderConfiguration options
     folderConfig = config.AddMarkdownProcessingFolder("/posts/", "~/Pages/__MarkdownPageTemplate.cshtml");
@@ -424,17 +467,28 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {  
     ...
     app.UseMarkdown();
-    
+
+    app.UseRouting();
     app.UseStaticFiles();
-    app.UseMvc();
+
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapRazorPages();
+
+        // Required only in ControllerAndView mode
+        endpoints.MapDefaultControllerRoute();
+    });
 }
 ```        
 
 The `UseMarkdown()` method hooks up the middleware into the pipeline.
 
-Note that both `ConfigureServices()` and `Configure()` are required to reference the MVC middleware - `services.AddMvc()` and `app.UseMvc()` respectively - as the middleware relies on MVC and Razor to render the Razor host view template.
+MVC is only required when using `MarkdownPageModes.ControllerAndView`. If you use `MarkdownPageModes.MiddlewareAndStaticHtmlFile`, no MVC markdown controller route is required.
 
-### Create a Markdown Page View Template
+### Create a Markdown Page Template
+In `MarkdownPageModes.ControllerAndView` mode, Markdown is rendered into a Razor template via MVC. In `MarkdownPageModes.MiddlewareAndStaticHtmlFile` mode, Markdown is merged into a static HTML file directly in middleware.
+
+### Razor View Template (ControllerAndView)
 Markdown is just an HTML fragment, not a complete document, so a host template is required into which the rendered Markdown is embedded. To accomplish this the middleware uses a well-known MVC controller endpoint that loads the configured Razor view template that embeds the Markdown text.
 
 The middleware reads in the Markdown file from disk, and then uses a generic MVC controller method call the specified template to render the page containing your Markdown text as the content. The template is passed a `MarkdownModel` that includes `RenderedMarkdown` and `Title` properties.
@@ -509,6 +563,38 @@ A more complete template might also add a code highlighter ([highlightJs](https:
 
     </script>
 }
+```
+
+### Static HTML Template (MiddlewareAndStaticHtmlFile)
+When using middleware-only rendering, configure `MarkdownPageMode = MarkdownPageModes.MiddlewareAndStaticHtmlFile` and provide a static template file (default: `~/__MarkdownPageTemplate.html`).
+
+The static template supports:
+
+* `{{ Title }}` for the page title
+* `{{ RenderedMarkdown }}` for rendered Markdown HTML
+
+which is replaced when the title and content when rendered.
+
+If the static template file is not found, the middleware writes the rendered Markdown HTML directly to the response.
+
+Make sure the static template file is deployed with your app (for example by marking it as Content in your project file and setting copy behavior for output/publish).
+
+Example static template:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ Title }}</title>
+</head>
+<body>
+    <main>
+        {{ RenderedMarkdown }}
+    </main>
+</body>
+</html>
 ```
 
 ### Title Rendering


### PR DESCRIPTION
Added ability to add use a static Html template to render Markdown rather than running a Rewrite to a controller handler with a View.

This feature is optional and in addition to Controller support.

By using a static template we lose the abililty to use inherit _Layout.cshtml from the site, so the Html template needs to be static and fixed with only the Content and Title getting merged into the page.

Changes:

* Add `MarkdownConfiguration.MarkdownPageMode` property to determine whether `ControllerAndView` or `MiddlewareAndStaticHtmlFile` is used.
* Add Config and Default Values for the Static Page Template Path. Default is: `~/__MarkdownPageTemplate.html` where `~/` refers to the content root.
* Middleware now conditionally checks based on `MarkdownPageMode` whether to re-write or use the StaticFile template specified to merge Markdown.
* The new Static template handler writes out directly into the Response stream.
* If the template is not found the raw Markdown is rendered.
* The template merges `{{ RenderedContent }}` and `{{ Title }}` (in the `<head>`)